### PR TITLE
Fix small demo bugs

### DIFF
--- a/scenes/demos/inventory/item.gd
+++ b/scenes/demos/inventory/item.gd
@@ -7,6 +7,7 @@ extends Area2D
 var dragging := false
 var _drag_start_pos: Vector2i
 var occupied_cells: Array[Vector2i]
+var tween: Tween
 
 @onready var top_left_cell = Vector2i(0, 0) :
 	set(value):
@@ -16,7 +17,7 @@ var occupied_cells: Array[Vector2i]
 			top_left_cell = value
 
 		var world_pos := grid.map_to_world(top_left_cell)
-		var tween := create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUINT)
+		tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUINT)
 		tween.tween_property(self, "global_position", world_pos, 0.3)
 
 
@@ -50,6 +51,7 @@ func _input(event: InputEvent) -> void:
 
 
 func _start_dragging() -> void:
+	tween.stop()
 	z_index = 1
 	dragging = true
 	_drag_start_pos = top_left_cell

--- a/scenes/demos/inventory/item.gd
+++ b/scenes/demos/inventory/item.gd
@@ -62,7 +62,7 @@ func _stop_dragging() -> void:
 	z_index = 0
 	dragging = false
 
-	var target_cell := grid.world_to_map(global_position + _get_centered_offset() * 0.5)
+	var target_cell := _get_mouse_top_left_cell()
 
 	var target_cells := _get_cells(target_cell)
 	if not grid.has_cells(target_cells) or not grid.are_values_null(target_cells):
@@ -85,6 +85,8 @@ func _move_to(cell: Vector2i) -> void:
 func _get_centered_offset() -> Vector2:
 	return (Vector2(size) * 0.5) * Vector2(grid.cell_size)
 
+func _get_mouse_top_left_cell() -> Vector2i:
+	return grid.world_to_map(get_global_mouse_position() + Vector2(grid.cell_size)/2.0 - _get_centered_offset())
 
 # Get all cells the item will occupy based on its size.
 func _get_cells(origin: Vector2i) -> Array[Vector2i]:
@@ -106,7 +108,7 @@ func _get_next_empty_cell_in_grid() -> Vector2i:
 func _draw() -> void:
 	# Highlight cells the item will occupy.
 	if dragging:
-		var current_cell := grid.world_to_map(global_position + _get_centered_offset() * 0.5)
+		var current_cell := _get_mouse_top_left_cell()
 		if not grid.has_cells(_get_cells(current_cell)):
 			return
 


### PR DESCRIPTION
Fix two bugs:
- When you drag an item, it's slightly off center. It was calculated based on globalPosition, and I changed it to use mouse coords, which fixes the issue. (make sure to test for larger sizes)
- When you let go of left click and quickly quick again, the tween continues, which means you get some glitchiness. I made the tween a private variable and added a tween.stop when you start drag.

https://github.com/BenjaTK/Criss-Cross/assets/86272030/d0a5afd2-41ce-4567-8952-5ca5fc89a467

